### PR TITLE
fix: could not find a declaration file for module '@stadiamaps/maplibre-search-box'

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "exports": {
     ".": {
       "require": "./dist/maplibre-search-box.umd.js",
-      "import": "./dist/maplibre-search-box.mjs"
+      "import": "./dist/maplibre-search-box.mjs",
+      "types": "./dist/index.d.ts"
     },
     "./dist/*.css": {
       "require": "./dist/*.css",


### PR DESCRIPTION
This PR fixes the following error that prevent IDE like vscode to use the embedded typings:

```
Could not find a declaration file for module '@stadiamaps/maplibre-search-box'.
'/.../node_modules/@stadiamaps/maplibre-search-box/dist/maplibre-search-box.mjs' implicitly has an 'any' type.
There are types at '/.../node_modules/@stadiamaps/maplibre-search-box/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@stadiamaps/maplibre-search-box' library may need to update its package.json or typings.ts(7016)
```

Thanks for this package :pray: 