### PR TITLE
feat: add onResults callback option

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ export class MapLibreSearchControlOptions {
   minWaitPeriodMs = 100;
   layers: GeocodingLayer[] = null;
   onResultSelected?: (feature: GeocodingGeoJSONFeature) => void;
+  onResults?: (results: { query: string; features: FeaturePropertiesV2[] }) => void;
   baseUrl: string | null = null;
 }
 ```
@@ -153,6 +154,12 @@ results, use `['coarse']` for the best performance.
 
 A callback to be invoked whenever a result is selected by the user. This is invoked with a single argument, the
 `GeocodingFeature` for the result. This allows you take an action (such as autofilling your own form).
+
+### `onResults`
+
+A callback to be invoked whenever a search request completes, with the query string and the resulting features
+(which may be an empty array). This is useful for tracking analytics (e.g., search text and result count) without
+needing to duplicate the underlying search request. It is not invoked if the request fails.
 
 ### `baseUrl`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,10 @@ export class MapLibreSearchControlOptions {
   minWaitPeriodMs = 100;
   layers: LayerId[] = null;
   onResultSelected?: (feature: FeaturePropertiesV2) => void;
+  onResults?: (results: {
+    query: string;
+    features: FeaturePropertiesV2[];
+  }) => void;
   baseUrl: string | null = null;
 }
 
@@ -262,6 +266,10 @@ export class MapLibreSearchControl implements IControl {
             if (this.lastRequestAt === requestAt) {
               this.clearResults();
               this.resultFeatures = features;
+              this.options.onResults?.({
+                query: searchString,
+                features: this.resultFeatures,
+              });
               if (this.resultFeatures.length > 0) {
                 for (const result of this.resultFeatures) {
                   this.addResult(result);


### PR DESCRIPTION
## Summary

Adds an optional `onResults` callback to `MapLibreSearchControlOptions`, invoked whenever a search request completes successfully - with the query string and the resolved result features (whether zero or more).

## Motivation

Consumers currently have no way to observe that a search completed (and with what result count) without either duplicating the geocoding request themselves or monkey-patching internals. A common use case is firing an analytics event (search text + result count) once results are available - something that's naturally already computed inside `onInput()` right after `resultFeatures` is set.

## Changes

- `MapLibreSearchControlOptions`: new optional field
  ```ts
  onResults?: (results: { query: string; features: FeaturePropertiesV2[] }) => void;
  ```
- `onInput()`: after `this.resultFeatures = features;` is assigned (for both the `useSearch` and `autocompleteV2` branches, and gated by the existing `lastRequestAt === requestAt` staleness check), the callback is invoked with the current query string and features - **before** branching into `addResult(...)` vs `onNoResults()`, so it fires uniformly for 0 and N results.
- Not invoked in the `catch` block - a failed request isn't "results returned", so the existing `console.warn` error handling is unchanged.

## Compatibility

Purely additive: the new field is optional and defaults to `undefined`, so existing consumers are unaffected.

## Testing

- `npm run build` succeeds (verified pre-existing unrelated `TS2345` warning in `subtitle()` typing is present on `main` too, unaffected by this change).