### PR TITLE
Add lang option for localized search results

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ export class MapLibreSearchControlOptions {
   layers: GeocodingLayer[] = null;
   onResultSelected?: (feature: GeocodingGeoJSONFeature) => void;
   baseUrl: string | null = null;
+  lang: string | null = null;
 }
 ```
 
@@ -159,6 +160,11 @@ A callback to be invoked whenever a result is selected by the user. This is invo
 An optional override to the base API URL. This defaults to the primary Stadia Maps API endpoint. If you want
 to use our [EU endpoints](https://docs.stadiamaps.com/eu-gdpr-endpoints/) to ensure traffic is handled by EU servers,
 set the `baseUrl` to `https://api-eu.stadiamaps.com`.
+
+### `lang`
+
+An optional [BCP47](https://en.wikipedia.org/wiki/IETF_language_tag) language tag (e.g. `en`, `de`, `fr`) used to
+request results localized in that language. When unset, the API's default language behavior is used.
 
 ## Development
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ export class MapLibreSearchControlOptions {
   layers: LayerId[] = null;
   onResultSelected?: (feature: FeaturePropertiesV2) => void;
   baseUrl: string | null = null;
+  lang: string | null = null;
 }
 
 export class MapLibreSearchControl implements IControl {
@@ -213,6 +214,10 @@ export class MapLibreSearchControl implements IControl {
 
           if (this.options.layers) {
             params.layers = this.options.layers;
+          }
+
+          if (this.options.lang) {
+            params.lang = this.options.lang;
           }
 
           let focusPoint = this.options.fixedFocusPoint;

--- a/test/sanity.test.ts
+++ b/test/sanity.test.ts
@@ -31,6 +31,18 @@ describe("search-control", () => {
     expectTypeOf(control).toMatchTypeOf<IControl>();
   });
 
+  it("defaults lang to null", () => {
+    const control = new MapLibreSearchControl({});
+
+    expect(control.options.lang).toBeNull();
+  });
+
+  it("accepts a lang option", () => {
+    const control = new MapLibreSearchControl({ lang: "fr" });
+
+    expect(control.options.lang).toBe("fr");
+  });
+
   it.todo("can be added to map", () => {
     const { mapEl } = setupMap();
     expect(mapEl).toMatchSnapshot();


### PR DESCRIPTION
## Motivation

Stadia's geocoding endpoints support an optional `lang` (BCP47) query parameter that localizes result content itself, not just static UI text. Today this widget has no way to set it, so results always come back in whatever language the backend defaults to, regardless of the end user's locale.

## Change

- Add `lang: string | null = null` to `MapLibreSearchControlOptions`.
- When set, forward it as `params.lang` on both the autocomplete and search requests.

This is opt-in and backwards compatible: when `lang` is not set (default), behavior is unchanged.

## Testing

- Added unit tests covering the default (`null`) and an explicit `lang` value being accepted on the control's options.
- Confirmed via the `@stadiamaps/api` client that `lang` is a valid, already-supported property on both the autocomplete and search request types, and is forwarded through to the outgoing request's query parameters.